### PR TITLE
add final bundle packages log info

### DIFF
--- a/crosspm/adapters/artifactoryaql2.py
+++ b/crosspm/adapters/artifactoryaql2.py
@@ -82,6 +82,10 @@ class ArtifactoryAql2(ArtifactoryAql):
                         downloader._config.trigger_package)
 
         bundle_packages = bundle.calculate().values()
+
+        self._log.info('Final bundle packages with contracts:')
+        print_packages_by_contracts_scheme(self._log, bundle_packages)
+
         for p in bundle_packages:
             _packages_found[p.name] = Package(p.name, p.art_path, p, {}, downloader, self, parser,
                                               {}, {})
@@ -162,3 +166,7 @@ class ArtifactoryAql2(ArtifactoryAql):
 
                 self._log.error('Error[{}]{}'.format(err_status,
                                                (': {}'.format(err_msg)) if err_msg else ''))
+
+def print_packages_by_contracts_scheme(logger, packages):
+        for p in packages:
+            logger.info(f"  {p}")


### PR DESCRIPTION
Add simple final print selected packages with there contracts. Suppose, that it will be enough for beginning.
And if there will be a demand to investigate the whole graph of decisions, do it in another feature